### PR TITLE
Addressing context menu items on mobile & adding image modal

### DIFF
--- a/flan/package.json
+++ b/flan/package.json
@@ -12,7 +12,7 @@
     "format": "prettier --plugin-search-dir . --write ."
   },
   "devDependencies": {
-    "@skeletonlabs/skeleton": "2.0.0",
+    "@skeletonlabs/skeleton": "2.2.0",
     "@skeletonlabs/tw-plugin": "0.1.0",
     "@sveltejs/adapter-auto": "^2.0.0",
     "@sveltejs/adapter-static": "^2.0.3",

--- a/flan/pnpm-lock.yaml
+++ b/flan/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   '@floating-ui/dom':
     specifier: 1.5.1
@@ -16,8 +20,8 @@ dependencies:
 
 devDependencies:
   '@skeletonlabs/skeleton':
-    specifier: 2.0.0
-    version: 2.0.0(svelte@4.2.0)
+    specifier: 2.2.0
+    version: 2.2.0(svelte@4.2.0)
   '@skeletonlabs/tw-plugin':
     specifier: 0.1.0
     version: 0.1.0(tailwindcss@3.3.3)
@@ -414,8 +418,8 @@ packages:
     resolution: {integrity: sha512-C16M+IYz0rgRhWZdCmK+h58JMv8vijAA61gmz2rspCSwKwzBebpdcsiUmwrtJRdphuY30i6BSLEOP8ppbNLyLg==}
     dev: true
 
-  /@skeletonlabs/skeleton@2.0.0(svelte@4.2.0):
-    resolution: {integrity: sha512-8SaDK3kEUU57cSb/5a984EbINgnOPzShlkwPkduAhqc71SEqhRvx+RlLEpe1174NAYi00oi//LguIAYuVrSfBA==}
+  /@skeletonlabs/skeleton@2.2.0(svelte@4.2.0):
+    resolution: {integrity: sha512-pSi1yeZo1tsGnMqbBeTfTxfEqcZUM1n9RT/7KQVSiBcENB9L0kesbkv5TlZhW6MxOwf0QRVfkaeCc5ymz4/OHw==}
     peerDependencies:
       svelte: ^3.56.0 || ^4.0.0
     dependencies:
@@ -1225,6 +1229,7 @@ packages:
   /node-gyp-build-optional-packages@5.0.3:
     resolution: {integrity: sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==}
     hasBin: true
+    requiresBuild: true
     dev: false
     optional: true
 
@@ -1946,7 +1951,3 @@ packages:
       peerjs-js-binarypack: 2.0.0
       webrtc-adapter: 8.2.3
     dev: false
-
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false

--- a/flan/src/lib/ImageModal.svelte
+++ b/flan/src/lib/ImageModal.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { getModalStore } from '@skeletonlabs/skeleton';
+	import type { IMessage } from './types';
+	const modalStore = getModalStore();
+	const message: IMessage = $modalStore[0].meta?.message;
+</script>
+
+<div class="flex items-center justify-center">
+	<img
+		on:contextmenu={(e) => {
+			e.preventDefault();
+			e.stopPropagation();
+			return false;
+		}}
+		class="rounded-lg max-h-[80vh]"
+		src={message.payload?.src}
+		alt={message.payload?.name} />
+</div>
+
+<style>
+	img {
+		-webkit-user-select: none;
+		-webkit-touch-callout: none;
+		user-select: none;
+	}
+</style>

--- a/flan/src/lib/ImageModal.svelte
+++ b/flan/src/lib/ImageModal.svelte
@@ -2,7 +2,7 @@
 	import { getModalStore } from '@skeletonlabs/skeleton';
 	import type { IMessage } from './types';
 	const modalStore = getModalStore();
-	const message: IMessage = $modalStore[0].meta?.message;
+	$:message = $modalStore[0].meta?.message as IMessage;
 </script>
 
 <div class="flex items-center justify-center">

--- a/flan/src/lib/Message.svelte
+++ b/flan/src/lib/Message.svelte
@@ -6,10 +6,13 @@
 	import DownloadIcon from './svgs/Download.svelte';
 	import { fly } from 'svelte/transition';
 	import MessageContents from './MessageContents.svelte';
+	import { isDesktop } from './stores';
 
 	const toastStore = getToastStore();
 	export let message: IMessage;
-	let showCopy = false;
+	let baseShowCopy = false;
+
+	$: showCopy = $isDesktop ? baseShowCopy : true;
 
 	function copyMsg() {
 		if (!message.text) return;
@@ -47,17 +50,20 @@
 	{:else}
 		<!-- Curor here is all pointer because of the roll -->
 		<!-- FRIEND :) -->
+		<!-- svelte-ignore a11y-no-static-element-interactions 
+			-- in the event of mouseenter/leave on mobile use these 
+			aria-haspopup="true"
+			role="button"> 
+		-->
 		<div
 			on:mouseenter={() => {
-				showCopy = true;
+				baseShowCopy = true;
 			}}
 			on:mouseleave={() => {
-				showCopy = false;
+				baseShowCopy = false;
 			}}
 			class="grid grid-cols-[6fr_1fr] lg:grid-cols-[4fr_1fr_1fr] gap-2 mr-12 lg:mr-0 ml-2"
-			aria-haspopup="true"
-			role="button"
-			tabindex={message.timestamp}>
+			>
 			<div class="card p-4 variant-soft rounded-tl-none space-y-2">
 				<header class="flex justify-between items-center">
 					<p class="font-bold">Friend 😸</p>

--- a/flan/src/lib/MessageContents.svelte
+++ b/flan/src/lib/MessageContents.svelte
@@ -1,16 +1,33 @@
 <script lang="ts">
 	import { MessageType, type IMessage } from './types';
 	import FileIcon from './svgs/File.svelte';
+	import { getModalStore, type ModalSettings } from '@skeletonlabs/skeleton';
+
+	const modalStore = getModalStore();
 	export let message: IMessage;
+	const modal: ModalSettings = {
+		type: 'component',
+		component: 'imageModal',
+		meta: { message: message }
+	};
 </script>
 
 {#if message.type === MessageType.Text}
 	<p>{message.text}</p>
 {:else if message.type === MessageType.Image}
 	<div class="flex items-center justify-center">
-		<a href={message.payload?.src} download={message.payload?.name}>
-			<img class="rounded-lg max-h-[60vh]" src={message.payload?.src} alt={message.payload?.name} />
-		</a>
+		<button on:click={() => modalStore.trigger(modal)}>
+			<!-- https://stackoverflow.com/questions/3413683/disabling-the-context-menu-on-long-taps-on-android -->
+			<img
+				on:contextmenu={(e) => {
+					e.preventDefault();
+					e.stopPropagation();
+					return false;
+				}}
+				class="rounded-lg max-h-[60vh] hover:cursor-pointer"
+				src={message.payload?.src}
+				alt={message.payload?.name} />
+		</button>
 	</div>
 {:else if message.type === MessageType.Audio}
 	<div class="flex flex-col gap-3 items-center justify-center">
@@ -30,3 +47,12 @@
 		<code>{message.payload?.name}</code>
 	</div>
 {/if}
+
+<style>
+	/* https://github.com/react-native-webview/react-native-webview/issues/1183 */
+	img {
+		-webkit-user-select: none;
+		-webkit-touch-callout: none;
+		user-select: none;
+	}
+</style>

--- a/flan/src/lib/MessageContents.svelte
+++ b/flan/src/lib/MessageContents.svelte
@@ -5,11 +5,11 @@
 
 	const modalStore = getModalStore();
 	export let message: IMessage;
-	const modal: ModalSettings = {
+	$: modal = {
 		type: 'component',
 		component: 'imageModal',
 		meta: { message: message }
-	};
+	} as ModalSettings;
 </script>
 
 {#if message.type === MessageType.Text}

--- a/flan/src/lib/MessageContents.svelte
+++ b/flan/src/lib/MessageContents.svelte
@@ -8,7 +8,9 @@
 	<p>{message.text}</p>
 {:else if message.type === MessageType.Image}
 	<div class="flex items-center justify-center">
-		<img class="rounded-lg max-h-[60vh]" src={message.payload?.src} alt={message.payload?.name} />
+		<a href={message.payload?.src} download={message.payload?.name}>
+			<img class="rounded-lg max-h-[60vh]" src={message.payload?.src} alt={message.payload?.name} />
+		</a>
 	</div>
 {:else if message.type === MessageType.Audio}
 	<div class="flex flex-col gap-3 items-center justify-center">

--- a/flan/src/lib/stores.ts
+++ b/flan/src/lib/stores.ts
@@ -3,3 +3,16 @@ import { writable, type Writable } from 'svelte/store';
 
 export const peerId = writable<string | null>(null);
 export const advancedMode: Writable<boolean> = localStorageStore('advancedMode', false);
+
+// REF: https://svelte.dev/examples/custom-stores
+function createMediaQueryStore(query: string) {
+  const initialValue = window.matchMedia(query).matches;
+  let isDesktop = writable<boolean>(initialValue);
+  window
+    .matchMedia(query)
+    .addEventListener('change', (e) => (isDesktop.set(e.matches)));
+  return isDesktop;
+}
+
+// based on lg tailwind viewport
+export const isDesktop = createMediaQueryStore('(min-width: 1024px)');

--- a/flan/src/routes/+layout.svelte
+++ b/flan/src/routes/+layout.svelte
@@ -4,7 +4,13 @@
 	// Highlight JS
 	import hljs from 'highlight.js';
 	import 'highlight.js/styles/github-dark.css';
-	import { storeHighlightJs } from '@skeletonlabs/skeleton';
+	import {
+		Modal,
+		storeHighlightJs,
+		Toast,
+		type ModalComponent,
+	} from '@skeletonlabs/skeleton';
+	import ImageModal from '$lib/ImageModal.svelte';
 	storeHighlightJs.set(hljs);
 
 	// Floating UI for Popups
@@ -16,13 +22,19 @@
 
 	// Initialise stores
 	import { initializeStores } from '@skeletonlabs/skeleton';
-	import { Toast } from '@skeletonlabs/skeleton';
 	initializeStores();
 
 	onMount(() => {
 		console.log('layout mounted', $page);
 	});
+
+	const modalComponentRegistry: Record<string, ModalComponent> = {
+		imageModal: {
+			ref: ImageModal,
+		},
+	};
 </script>
 
 <Toast />
+<Modal components={modalComponentRegistry}/>
 <slot />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "nakl",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
- Removed context menu on Android and iOS. 
- Custom image modal as per [Skeleton's modal guide](https://www.skeleton.dev/utilities/modals)
- Updated Skeleton from 2.0.0 to 2.2.0
- Show download & copy buttons on mobile

Addresses tickets:
- [Share via context menu](https://trello.com/c/eS0GIajT/79-share-via-context-menuon-android-apple-image-modal)
- [Image focus image on Skeleton modal](https://trello.com/c/Cr6kG7vz/157-image-focus-skeleton-modal-when-click-image)
- [Show copy & download buttons on mobile](https://trello.com/c/czbgyJ3R/146-consider-showing-the-copy-and-download-buttons-on-mobile-view-instead-of-using-hover)